### PR TITLE
Quote filename when passing it to exec()

### DIFF
--- a/src/SrtParser/srtFile.php
+++ b/src/SrtParser/srtFile.php
@@ -231,7 +231,7 @@ class srtFile{
 	 */
 	private function convertEncoding(){
 		$exec = array();
-		exec('file -i '.$this->filename, $exec);
+		exec('file -i "'.$this->filename.'"', $exec);
 		$res_exec = explode('=', $exec[0]);
 
 


### PR DESCRIPTION
File encoding detection will fail if the filename contains space or
whatever shell operator.
